### PR TITLE
Correct spelling error ('numver' -> 'Number')

### DIFF
--- a/R/ggpage_build.R
+++ b/R/ggpage_build.R
@@ -7,7 +7,7 @@
 #'
 #' @param book Character or data.frame. Can either have each element be a
 #'   seperate line or having each element being seperate words.
-#' @param lpp Numeric. Lines Per Page. numver of lines allocated for each page.
+#' @param lpp Numeric. Lines Per Page. Number of lines allocated for each page.
 #' @param character_height Numeric. Relative size of the height of each letter
 #'   compared to its width.
 #' @param vertical_space Numeric. Distance between each lines vertically.

--- a/R/ggpage_quick.R
+++ b/R/ggpage_quick.R
@@ -2,7 +2,7 @@
 #'
 #' @param book Character or data.frame. Can either have each element be a
 #'   seperate line or having each element being seperate words.
-#' @param lpp Numeric. Lines Per Page. numver of lines allocated for each page.
+#' @param lpp Numeric. Lines Per Page. Number of lines allocated for each page.
 #' @param character_height Numeric. Relative size of the height of each letter
 #'   compared to its width.
 #' @param vertical_space Numeric. Distance between each lines vertically.

--- a/man/ggpage_build.Rd
+++ b/man/ggpage_build.Rd
@@ -12,7 +12,7 @@ ggpage_build(book, lpp = 25, character_height = 3, vertical_space = 1,
 \item{book}{Character or data.frame. Can either have each element be a
 seperate line or having each element being seperate words.}
 
-\item{lpp}{Numeric. Lines Per Page. numver of lines allocated for each page.}
+\item{lpp}{Numeric. Lines Per Page. Number of lines allocated for each page.}
 
 \item{character_height}{Numeric. Relative size of the height of each letter
 compared to its width.}

--- a/man/ggpage_quick.Rd
+++ b/man/ggpage_quick.Rd
@@ -12,7 +12,7 @@ ggpage_quick(book, lpp = 25, character_height = 3, vertical_space = 1,
 \item{book}{Character or data.frame. Can either have each element be a
 seperate line or having each element being seperate words.}
 
-\item{lpp}{Numeric. Lines Per Page. numver of lines allocated for each page.}
+\item{lpp}{Numeric. Lines Per Page. Number of lines allocated for each page.}
 
 \item{character_height}{Numeric. Relative size of the height of each letter
 compared to its width.}


### PR DESCRIPTION
Minor change in the Roxygen and manpage documentation for `ggpage_quick` and `ggpage_build` to alter 'numver' to 'Number'.